### PR TITLE
Ensure required package jq is available

### DIFF
--- a/scripts/init-nanit.sh
+++ b/scripts/init-nanit.sh
@@ -23,6 +23,32 @@ fi
 read -p 'Nanit Email: ' EMAIL
 read -sp 'Nanit Password: ' PASSWORD
 
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+  echo "jq is not installed. Installing..."
+
+  # Install jq using the appropriate package manager for your system
+  if [[ -f /etc/os-release ]]; then
+    # For systems using systemd
+    . /etc/os-release
+    case "$ID" in
+      debian|ubuntu|raspbian)
+        sudo apt-get update && sudo apt-get install -y jq
+        ;;
+      centos|fedora|rhel)
+        sudo yum install -y jq
+        ;;
+      *)
+        echo "Unsupported distribution. Please install jq manually."
+        exit 1
+        ;;
+    esac
+  else
+    echo "Unable to determine operating system. Please install jq manually."
+    exit 1
+  fi
+fi
+
 # TODO: show json and disable --silent in curl when debug flag is present
 LOGIN=$(jq -n --arg email "$EMAIL" --arg password "$PASSWORD" '{email: $email, password: $password, channel: "email"}' | curl --silent --header 'nanit-api-version: 1' --header 'Content-Type: application/json' -d@- https://api.nanit.com/login)
 


### PR DESCRIPTION
Fixes #18 

The script `init-nanit.sh` assumes that the user's environment already has `jq` installed.

Occasionally, this may not be the case as seen in these examples:
- https://github.com/indiefan/home_assistant_nanit/issues/18#issuecomment-2459337162
- https://community.home-assistant.io/t/nanit-baby-monitor-integration/106928/401

Proposed changes:
- Install `jq` via system package manager if it is missing