### PR TITLE
feat: Enhance Nanit integration with WebSocket resilience and improved controls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -52,6 +52,20 @@ NANIT_PASSWORD=xxxxxxxxxx
 # Topic prefix (default: nanit)
 # NANIT_MQTT_PREFIX=mynanit
 
+# MQTT Reliability (switches) -------------------------------------------------
+
+# Enable automatic WebSocket reset when MQTT commands fail (default: false)
+# Recommended: true for production environments to resolve "half-dead" connections
+# that can receive data but cannot send control commands
+# NANIT_MQTT_RESET_WHEN_FAILED=true
+
+# Command timeout before marking as failed (default: 500ms)
+# Only used when NANIT_MQTT_RESET_WHEN_FAILED=true
+# Lower values provide faster failure detection but may cause false positives
+# Higher values are more tolerant but slower to detect real failures
+# Recommended range: 500ms to 2s
+# NANIT_WEBSOCKET_TIMEOUT=1s
+
 # Event Polling ----------------------------------------------------------------
 
 # While Nanit doesn't provide a stream of events to subscribe to, you can poll

--- a/cmd/nanit/main.go
+++ b/cmd/nanit/main.go
@@ -35,6 +35,12 @@ func main() {
 			// 300 second (5 min) default message timeout (unseen messages are ignored once they are this old)
 			MessageTimeout: utils.EnvVarSeconds("NANIT_EVENTS_MESSAGE_TIMEOUT", 300*time.Second),
 		},
+		WebSocketReset: app.WebSocketResetOpts{
+			// Reset behavior disabled by default
+			Enabled: utils.EnvVarBool("NANIT_MQTT_RESET_WHEN_FAILED", false),
+			// 500ms default timeout for command responses
+			CommandTimeout: utils.EnvVarSeconds("NANIT_WEBSOCKET_TIMEOUT", time.Second),
+		},
 	}
 
 	if utils.EnvVarBool("NANIT_RTMP_ENABLED", true) {

--- a/docs/switches.md
+++ b/docs/switches.md
@@ -1,0 +1,110 @@
+# Switches
+
+App exposes cam controls by accepting MQTT commands and publishing state updates. See `NANIT_MQTT_*` variables in the [.env.sample](../.env.sample) file for configuration.
+
+## Reliability Configuration
+
+For improved reliability when camera WebSocket connections become unresponsive, the app supports automatic connection reset and command retry:
+
+### Environment Variables
+
+- **`NANIT_MQTT_RESET_WHEN_FAILED`** (default: `false`)
+  - Enables automatic WebSocket reset when MQTT commands fail
+  - When `true`, failed commands trigger WebSocket reconnection and automatic retry
+  - Helps resolve "half-dead" connections that receive data but can't send commands
+  - Recommended setting: `true` for production environments
+
+- **`NANIT_WEBSOCKET_TIMEOUT`** (default: `1s`)
+  - Timeout for camera command responses before marking as failed
+  - Only used when `NANIT_MQTT_RESET_WHEN_FAILED=true`
+  - Lower values provide faster failure detection but may cause false positives
+  - Higher values are more tolerant but slower to detect real failures
+  - Recommended range: `500ms` to `2s`
+
+### Example Configuration
+
+```bash
+# Enable automatic WebSocket reset on command failures
+NANIT_MQTT_RESET_WHEN_FAILED=true
+
+# Set command timeout to 1 second
+NANIT_WEBSOCKET_TIMEOUT=1s
+```
+
+**Note**: When disabled (default), the app behaves exactly as before with no additional overhead.
+
+## Command Topics
+
+The app subscribes to the following command topics to control camera functions:
+
+- `nanit/babies/{baby_uid}/night_light/switch` - turn night light on/off (payload: `true` or `false`)
+- `nanit/babies/{baby_uid}/standby/switch` - enable/disable standby mode (payload: `true` or `false`)
+
+## State Topics
+
+The app publishes the current state to these topics:
+
+- `nanit/babies/{baby_uid}/night_light` - current night light state (bool)
+- `nanit/babies/{baby_uid}/standby` - current standby state (bool)
+
+## Example Usage
+
+Turn on night light:
+```bash
+mosquitto_pub -h your-broker -t "nanit/babies/your-baby-uid/night_light/switch" -m "true"
+```
+
+Turn off night light:
+```bash
+mosquitto_pub -h your-broker -t "nanit/babies/your-baby-uid/night_light/switch" -m "false"
+```
+
+## Home Assistant Integration
+
+You can configure these switches in your [Home Assistant setup](./home-assistant.md) using MQTT switches:
+
+```yaml
+mqtt:
+  switch:
+    - name: "Baby Monitor Night Light"
+      state_topic: "nanit/babies/your-baby-uid/night_light"
+      command_topic: "nanit/babies/your-baby-uid/night_light/switch"
+      payload_on: "true"
+      payload_off: "false"
+      state_on: "true"
+      state_off: "false"
+      
+    - name: "Baby Monitor Standby"
+      state_topic: "nanit/babies/your-baby-uid/standby"
+      command_topic: "nanit/babies/your-baby-uid/standby/switch"
+      payload_on: "true"
+      payload_off: "false"
+      state_on: "true"
+      state_off: "false"
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**MQTT switches stop responding after hours of operation:**
+- Enable automatic WebSocket reset by setting `NANIT_MQTT_RESET_WHEN_FAILED=true`
+- This resolves "half-dead" WebSocket connections that can receive data but not send commands
+- Look for log messages like "Light command failed, attempting WebSocket reset" and "Retrying command after reconnection"
+
+**Commands timeout frequently:**
+- Adjust `NANIT_WEBSOCKET_TIMEOUT` (try increasing to `1s` or `2s`)
+- Check your network connection between the app and Nanit servers
+- Verify camera isn't overwhelmed by multiple stream connections
+
+### Debugging
+
+In case you run into trouble and need to see what is going on, you can try using [MQTT Explorer](http://mqtt-explorer.com/) to monitor both the command and state topics.
+
+With debug logging enabled, you'll see detailed WebSocket communication:
+```
+DBG Sending message data="type:REQUEST request:{id:1 type:PUT_CONTROL control:{nightLight:LIGHT_ON}}"
+DBG Received message data="type:RESPONSE response:{requestId:1 requestType:PUT_CONTROL statusCode:200}"
+```
+
+**Note**: Make sure to replace `your-baby-uid` with your actual baby UID, which you can find in the application logs or MQTT state topics. 

--- a/pkg/app/opts.go
+++ b/pkg/app/opts.go
@@ -14,6 +14,7 @@ type Opts struct {
 	MQTT             *mqtt.Opts
 	RTMP             *RTMPOpts
 	EventPolling     EventPollingOpts
+	WebSocketReset   WebSocketResetOpts
 }
 
 // NanitCredentials - user credentials for Nanit account
@@ -43,4 +44,13 @@ type EventPollingOpts struct {
 	Enabled         bool
 	PollingInterval time.Duration
 	MessageTimeout  time.Duration
+}
+
+// WebSocketResetOpts - options for WebSocket reset behavior
+type WebSocketResetOpts struct {
+	// Enable reset behavior when commands fail
+	Enabled bool
+	
+	// Timeout for command responses before marking as failed
+	CommandTimeout time.Duration
 }

--- a/pkg/client/websocket_conn.go
+++ b/pkg/client/websocket_conn.go
@@ -170,3 +170,10 @@ func getMessageBytes(data *Message) []byte {
 
 	return out
 }
+
+// Close - closes the underlying WebSocket connection
+func (conn *WebsocketConnection) Close() {
+	if conn.socket != nil && conn.socket.IsConnected {
+		conn.socket.Close()
+	}
+}

--- a/pkg/mqtt/mqtt.go
+++ b/pkg/mqtt/mqtt.go
@@ -11,8 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type SendLightCommandHandler func(nightLightState bool)
-type SendStandbyCommandHandler func(standbyState bool)
+type SendLightCommandHandler func(babyUID string, nightLightState bool)
+type SendStandbyCommandHandler func(babyUID string, standbyState bool)
 
 // Connection - MQTT context
 type Connection struct {
@@ -90,7 +90,7 @@ func (conn *Connection) subscribeToLightCommand() {
 				Str("payload", string(msg.Payload())).
 				Msg("Received light command")
 
-			conn.sendLightCommandHandler(enabled)
+			conn.sendLightCommandHandler(babyUID, enabled)
 		default:
 			log.Warn().Str("command", command).Msg("Unknown command received")
 		}
@@ -135,7 +135,7 @@ func (conn *Connection) subscribeToStandbyCommand() {
 				Str("payload", string(msg.Payload())).
 				Msg("Received standby command")
 
-			conn.sendStandbyCommandHandler(enabled)
+			conn.sendStandbyCommandHandler(babyUID, enabled)
 		default:
 			log.Warn().Str("command", command).Msg("Unknown command received")
 		}


### PR DESCRIPTION

This comprehensive update combines multiple enhancements to the Nanit Home Assistant integration:

## WebSocket Connection Reset Mechanism
- Implements automatic WebSocket reconnection when commands fail to receive responses
- Configurable timeout system to detect and recover from 'half-dead' connections
- Automatic command retry after successful reconnection
- Resolves MQTT switch unresponsiveness issues that required manual container restarts

## Enhanced Camera Controls
- Added standby mode toggle support for compatible Nanit cameras
- Improved light switch functionality with initial state support
- Refactored MQTT light hooks for better reliability
- Fixed crashes when MQTT is not enabled

## Configuration Options
- NANIT_MQTT_RESET_WHEN_FAILED: Enable automatic WebSocket reset (default: false)
- NANIT_WEBSOCKET_TIMEOUT: Command response timeout (default: 1s)
- Backward compatible - features are opt-in

## Reliability Improvements
- Enhanced WebSocket connection lifecycle management
- Improved error handling and logging for debugging
- Cooldown bypass for immediate reconnection on failures
- Robust command tracking and retry mechanisms

## Documentation
- Comprehensive setup and troubleshooting guide in docs/switches.md
- Configuration examples and best practices
- Detailed explanation of the reset mechanism

This update ensures the Nanit integration remains stable and responsive over long periods while adding valuable new control capabilities.

Full transparency - this PR generation was created with assistance of AI (Claud 4 Sonnet). Please let me know if you have any questions or issues. I've tested on a set up with 2 cameras and it's been working fine for a week now.